### PR TITLE
Fix for the access store ui

### DIFF
--- a/exasol/ds/sandbox/runtime/ansible/roles/jupyter/files/notebook/access_store_ui.ipynb
+++ b/exasol/ds/sandbox/runtime/ansible/roles/jupyter/files/notebook/access_store_ui.ipynb
@@ -35,6 +35,7 @@
     "def get_access_store_ui(root_dir: str = '.'):\n",
     "    \n",
     "    from enum import Enum\n",
+    "    from pathlib import Path\n",
     "    import ipywidgets as widgets\n",
     "    from IPython.display import Javascript, display, clear_output\n",
     "    from exasol.secret_store import Secrets\n",


### PR DESCRIPTION
closes #91

When the code searching for the styles notebook was moved to the notebook-connector the import of the `pathlib` has disappeared with it.